### PR TITLE
Change return type of use the bus context (Subject -> Observable)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 25 17:20:11 BST 2015
+#Sun Nov 13 15:23:20 MSK 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/rxbus-android/src/main/java/net/jokubasdargis/rxbus/AndroidRxBus.java
+++ b/rxbus-android/src/main/java/net/jokubasdargis/rxbus/AndroidRxBus.java
@@ -19,6 +19,7 @@ package net.jokubasdargis.rxbus;
 import android.util.Log;
 import android.util.SparseArray;
 
+import rx.Observable;
 import rx.Observer;
 import rx.Scheduler;
 import rx.Subscription;
@@ -66,8 +67,8 @@ public final class AndroidRxBus implements Bus {
     }
 
     @Override
-    public <T> Subject<T, T> queue(Queue<T> queue) {
-        return bus.queue(queue);
+    public <T> Observable<T> asObservable(Queue<T> queue) {
+        return bus.asObservable(queue);
     }
 
     @Override

--- a/rxbus/src/main/java/net/jokubasdargis/rxbus/Bus.java
+++ b/rxbus/src/main/java/net/jokubasdargis/rxbus/Bus.java
@@ -16,10 +16,10 @@
 
 package net.jokubasdargis.rxbus;
 
+import rx.Observable;
 import rx.Observer;
 import rx.Scheduler;
 import rx.Subscription;
-import rx.subjects.Subject;
 
 /**
  * Event notification system which enforces use of dedicated queues to perform type safe pub/sub.
@@ -42,8 +42,9 @@ public interface Bus {
     <T> void publish(Queue<T> queue, T event);
 
     /**
-     * Converts the given {@link Queue} to a {@link Subject} to be used
+     * Converts the given {@link Queue} to a {@link Observable} to be used
      * outside the bus context (when combining Rx streams).
      */
-    <T> Subject<T, T> queue(Queue<T> queue);
+    <T> Observable<T> asObservable(Queue<T> queue);
+
 }

--- a/rxbus/src/main/java/net/jokubasdargis/rxbus/RxBus.java
+++ b/rxbus/src/main/java/net/jokubasdargis/rxbus/RxBus.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 
+import rx.Observable;
 import rx.Observer;
 import rx.Scheduler;
 import rx.Subscription;
@@ -112,7 +113,14 @@ public final class RxBus implements Bus {
      * {@inheritDoc}
      */
     @Override
-    public <T> Subject<T, T> queue(Queue<T> queue) {
+    public <T> Observable<T> asObservable(Queue<T> queue) {
+        return queue(queue).asObservable();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    private  <T> Subject<T, T> queue(Queue<T> queue) {
         Subject<T, T> subject = cache.get(queue);
         if (subject == null) {
             if (queue.getDefaultEvent() != null) {


### PR DESCRIPTION
When we want to  use the bus context of combining Rx streams we can make a mistake with use subject:
like `bus.queue(queue).onNext(event)`

But for publish we need use:
```
 <T> void publish(Queue<T> queue, T event);
```

Do not allow to send events is without publish method may help change  Subject to Observable type

Example
```
zip(bus.asObservable(query), Observable.range(0, 100), new Func2<Object, Integer, Integer>() {
			@Override
			public Integer call(Object o, Integer integer) {
				return integer;
			}
		}).map(new Func1<Integer, String>() {
			@Override
			public String call(Integer integer) {
				return String.valueOf(integer);
			}
		}).subscribe(new Action1<String>() {
			@Override
			public void call(String s) {
				Toast.makeText(MainActivity.this, s, Toast.LENGTH_SHORT).show();
			}
		});
```